### PR TITLE
Fixes to enable Docker build to work under Debian without dind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,12 @@ RUN apt-get install -y supervisor default-jre
 VOLUME /var/log/supervisor
 
 # Install Packer
-RUN apt-get install -y unzip
+RUN apt-get install -y unzip curl
 RUN curl -L https://dl.bintray.com/mitchellh/packer/packer_0.8.1_linux_amd64.zip -o /tmp/packer.zip; unzip /tmp/packer.zip -d /usr/local/bin
 
 # Install Jenkins Swarm agent
 ENV HOME /home/jenkins-agent
 RUN useradd -c "Jenkins agent" -d $HOME -m jenkins-agent
-RUN usermod -aG docker jenkins-agent
 RUN curl --create-dirs -sSLo \
     /usr/share/jenkins/swarm-client-jar-with-dependencies.jar \
     http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/1.22/swarm-client-1.22-jar-with-dependencies.jar \

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -4,9 +4,6 @@ logfile=/var/log/supervisor/supervisord.log
 loglevel=debug
 childlogdir= /var/log/supervisor
 
-[program:wrapdocker]
-command=/usr/local/bin/wrapdocker
-
 [program:swarmagent]
 command=java -jar /usr/share/jenkins/swarm-client-jar-with-dependencies.jar -fsroot %(ENV_HOME)s %(ENV_SWARMARGS)s
 user=root


### PR DESCRIPTION
Made a couple changes to the Dockerfile and the supervisord.conf to correct these 2 issues:
1. The docker build was not completing successfully because curl wasn't installed and it is required, and it tried to create a "docker" user group that doesn't seem to be needed anymore.
2. The container was generating a bunch of error messages because it was trying to launch wrapdocker which no longer exists since the container doesn't use dind.
